### PR TITLE
Update html regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const htmlRegex = /\.css|\.js/g;
+const htmlRegex = /\.(css|js)$/gm;
 module.exports = function () {
     return {
         name: "vite-plugin-add-timestamp",


### PR DESCRIPTION
The old regex caused files with a ".json" extension to be renamed to ".js". I fixed the regex to only get exact ".css" and ".js" occurrences, ensuring that only names that have these extensions are modified.